### PR TITLE
structured date options and pass rectypes to write_fields_csv

### DIFF
--- a/lib/cspace_config_untangler/command_line.rb
+++ b/lib/cspace_config_untangler/command_line.rb
@@ -143,12 +143,22 @@ module CspaceConfigUntangler
       end
     end
 
-    desc 'fields_csv', 'write CSV containing field data'
+    desc 'write_fields_csv', 'write CSV containing field data'
     option :output, :desc => 'path to output file', :default => 'data/fields.csv'
-    def fields_csv
+    option :rectypes, :desc => 'Comma separated list of record types to include. Defaults to all.', :default => 'all'
+    option :structured_date,
+      :desc => 'explode: report all individual structured date fields; collapse: report the parent of individual structured date fields as the field',
+      :default => 'explode'
+    
+    def write_fields_csv
+      unless %w[explode collapse].include?(options[:structured_date])
+        puts '--structured_date parameter must be either "explode" or "collapse"'
+        exit
+      end
+      rt = options[:rectypes] == 'all' ? [] : options[:rectypes].split(',')
       fs = []
       get_profiles.each {|profile|
-        p = CCU::Profile.new(profile)
+        p = CCU::Profile.new(profile, rectypes: rt, structured_date_treatment: options[:structured_date].to_sym)
         p.fields.each{ |f| fs << f }
       }
       CSV.open(options[:output], 'wb'){ |csv|


### PR DESCRIPTION
When getting fields for a profile, gives the option to explode or collapse structured dates. 

explode will report one row for each individual structured date field (`dateDisplayDate`, `dateEarliestScalarValue`, etc.) 

collapse will report the structured date group xpath parent as the field, with data type = structured date.

This PR also adds the option to output fields csv only for selected rectypes, since this will be needed in order to pull data for creating converter templates, mappings hashes, and validation info.